### PR TITLE
Added copyright, gear, option, super, and shift symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,19 @@ unicons.cli("circle"); // ● on Unix
 
 Property | Default | Windows Console Fallback
 ---------|---------|-------------------------
-`check` | ✓ | √
-`cross` | ✖ | ×
 `arrowLeft` | ← | ←
 `arrowUp` | ↑ | ↑
 `arrowRight` | → | →
 `arrowDown` | ↓ | ↓
+`check` | ✓ | √
 `circle` | ● | o
+`cross` | ✖ | ×
+`copyright` | © | (c)
+`gear` | ⚙ | _
+`option` | ⌥ | _
+`super` | ⌘ | _
+`shift` | ⇧ | _
+
 
 The icon table is still very small :(<br>
 If you can't find your icon in the [icon table](https://github.com/peerigon/unicons#icon-table), don't hesitate to create a pull request.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ unicons.cli("circle"); // ● on Unix
 ## Icon table
 
 Property | Default | Windows Console Fallback
----------|---------|-------------------------
+---------|---------|-------------------------|
 `arrowLeft` | ← | ←
 `arrowUp` | ↑ | ↑
 `arrowRight` | → | →
@@ -41,14 +41,20 @@ Property | Default | Windows Console Fallback
 `circle` | ● | o
 `cross` | ✖ | ×
 `copyright` | © | (c)
-`gear` | ⚙ | _
-`option` | ⌥ | _
+`gear` | ⚙ | ⚙
+`option` | ⌥ | <
 `super` | ⌘ | _
-`shift` | ⇧ | _
+`shift` | ⇧ | ↑
 
 
 The icon table is still very small :(<br>
 If you can't find your icon in the [icon table](https://github.com/peerigon/unicons#icon-table), don't hesitate to create a pull request.
+
+
+## Contributing
+
+You can refer to the Unicode Character table site for integrating more characters: http://unicode-table.com/en
+
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,21 +1,33 @@
 var isWin = process.platform === "win32";
+
 var unicons = {
-    check: "✓",
-    cross: "✖",
     arrowLeft: "←",
     arrowUp: "↑",
     arrowRight: "→",
     arrowDown: "↓",
-    circle: "●"
+    check: "✓",
+    circle: "●",
+    copyright: "©",
+    cross: "✖",
+    gear: "⚙",
+    option: "⌥",
+    super: "⌘",
+    shift: "⇧"
 };
+
 var win32Cli = {
-    check: "\u221A",
-    cross: "\u00D7",
     arrowLeft: "\u2190",
     arrowUp: "\u2191",
     arrowRight: "\u2192",
     arrowDown: "\u2193",
-    circle: "\u006F"
+    check: "\u221A",
+    circle: "\u006F",
+    copyright: "\u0619",
+    cross: "\u00D7",
+    gear: "\u9881",
+    option: "\u8997",
+    shift: "\u8679",
+    super: "\u8984"
 };
 
 unicons.cli = function (name) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,11 +22,11 @@ var win32Cli = {
     arrowDown: "\u2193",
     check: "\u221A",
     circle: "\u006F",
-    copyright: "\u0619",
+    copyright: "\u00A9",
     cross: "\u00D7",
-    gear: "\u9881",
-    option: "\u8997",
-    shift: "\u8679",
+    gear: "\u2699",
+    option: "\u003C",
+    shift: "\u2191",
     super: "\u8984"
 };
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,17 @@
   "name": "unicons",
   "version": "0.0.1",
   "description": "Cross-platform unicode icon toolkit",
+  "author": "peerigon",
+  "contributors": [
+    {
+      "name": "peerigon",
+      "email": "hello@peerigon.com"
+    },
+    {
+      "name": "bmcminn",
+      "email": "labs@gbox.name"
+    }
+  ],
   "main": "lib/index.js",
   "scripts": {
     "eslint": "eslint ."
@@ -12,7 +23,6 @@
     "cli",
     "toolkit"
   ],
-  "author": "peerigon",
   "license": "Unlicense",
   "devDependencies": {
     "eslint": "^1.6.0",


### PR DESCRIPTION
- Alphabetized the names so they were easier to discover/refer to.
- Updated the READM.md file with new icons and alphabetized order.
- Updated Windows fallbacks for `shift` and `option` per @jhnns feedback
  - I'll be testing these on Windows once I can get back to my home machine :{P

**NOTE:** Have not tested in Windows for compatibility/fallbacks yet as I'm currently on my mac.
